### PR TITLE
Fase 2.1: modularización mantenimiento

### DIFF
--- a/backend/mantenimiento/__init__.py
+++ b/backend/mantenimiento/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'backend.mantenimiento.apps.MantenimientoConfig'

--- a/backend/mantenimiento/admin.py
+++ b/backend/mantenimiento/admin.py
@@ -1,0 +1,55 @@
+"""Configuración de admin para mantenimiento."""
+
+from django.contrib import admin
+
+from .models import (
+    HistorialMantenimiento,
+    IndicadorMantenimiento,
+    OrdenTrabajo,
+    OrdenTrabajoRepuesto,
+    PlanMantenimiento,
+    TipoMantenimiento,
+)
+
+
+@admin.register(TipoMantenimiento)
+class TipoMantenimientoAdmin(admin.ModelAdmin):
+    list_display = ['codigo', 'nombre', 'activo']
+    list_filter = ['activo']
+    search_fields = ['codigo', 'nombre']
+
+
+@admin.register(PlanMantenimiento)
+class PlanMantenimientoAdmin(admin.ModelAdmin):
+    list_display = ['codigo', 'maquina', 'nombre', 'tipo', 'activo']
+    list_filter = ['tipo', 'activo', 'maquina']
+    search_fields = ['codigo', 'nombre']
+
+
+class OrdenTrabajoRepuestoInline(admin.TabularInline):
+    model = OrdenTrabajoRepuesto
+    extra = 1
+
+
+@admin.register(OrdenTrabajo)
+class OrdenTrabajoAdmin(admin.ModelAdmin):
+    list_display = ['codigo', 'maquina', 'tipo', 'prioridad', 'estado', 'fecha_creacion', 'asignada_a']
+    list_filter = ['tipo', 'prioridad', 'estado', 'fecha_creacion']
+    search_fields = ['codigo', 'titulo']
+    date_hierarchy = 'fecha_creacion'
+    readonly_fields = ['duracion_real_horas', 'fecha_creacion']
+    inlines = [OrdenTrabajoRepuestoInline]
+
+
+@admin.register(HistorialMantenimiento)
+class HistorialMantenimientoAdmin(admin.ModelAdmin):
+    list_display = ['maquina', 'tipo', 'fecha', 'tiempo_parada_horas', 'realizado_por']
+    list_filter = ['tipo', 'fecha', 'maquina']
+    date_hierarchy = 'fecha'
+
+
+@admin.register(IndicadorMantenimiento)
+class IndicadorMantenimientoAdmin(admin.ModelAdmin):
+    list_display = ['maquina', 'periodo', 'fecha_inicio', 'mtbf_horas', 'mttr_horas', 'disponibilidad_porcentaje']
+    list_filter = ['periodo', 'maquina']
+    date_hierarchy = 'fecha_inicio'

--- a/backend/mantenimiento/apps.py
+++ b/backend/mantenimiento/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class MantenimientoConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'backend.mantenimiento'
+    verbose_name = 'Mantenimiento'

--- a/backend/mantenimiento/models.py
+++ b/backend/mantenimiento/models.py
@@ -1,0 +1,290 @@
+"""Modelos del dominio de mantenimiento."""
+
+from decimal import Decimal
+
+from django.conf import settings
+from django.core.validators import MinValueValidator
+from django.db import models
+
+
+class TipoMantenimiento(models.Model):
+    """Tipos de mantenimiento."""
+
+    codigo = models.CharField(max_length=10, unique=True, verbose_name="Código")
+    nombre = models.CharField(max_length=50)
+    descripcion = models.TextField(blank=True, verbose_name="Descripción")
+    activo = models.BooleanField(default=True)
+
+    class Meta:
+        app_label = 'core'
+        verbose_name = "Tipo de Mantenimiento"
+        verbose_name_plural = "Tipos de Mantenimiento"
+        ordering = ['codigo']
+
+    def __str__(self):
+        return f"{self.codigo} - {self.nombre}"
+
+
+class PlanMantenimiento(models.Model):
+    """Planes de mantenimiento preventivo."""
+
+    codigo = models.CharField(max_length=30, unique=True, verbose_name="Código")
+    maquina = models.ForeignKey(
+        'core.Maquina',
+        on_delete=models.CASCADE,
+        related_name='planes_mantenimiento',
+    )
+    nombre = models.CharField(max_length=200)
+    descripcion = models.TextField(blank=True, verbose_name="Descripción")
+    tipo = models.ForeignKey(TipoMantenimiento, on_delete=models.PROTECT)
+    frecuencia_dias = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text="Frecuencia en días",
+    )
+    frecuencia_horas_uso = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text="Frecuencia en horas de uso",
+    )
+    frecuencia_ciclos = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text="Frecuencia en ciclos de operación",
+    )
+    tareas = models.JSONField(
+        default=list,
+        help_text="Lista de tareas: [{nombre, descripcion, duracion_min}]",
+    )
+    repuestos_necesarios = models.JSONField(
+        default=list,
+        help_text="Lista de repuestos: [{repuesto_id, cantidad}]",
+    )
+    duracion_estimada_horas = models.DecimalField(max_digits=5, decimal_places=2)
+    activo = models.BooleanField(default=True)
+    creado_por = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        related_name='planes_creados',
+    )
+    fecha_creacion = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        app_label = 'core'
+        verbose_name = "Plan de Mantenimiento"
+        verbose_name_plural = "Planes de Mantenimiento"
+        ordering = ['maquina', 'codigo']
+
+    def __str__(self):
+        return f"{self.codigo} - {self.nombre}"
+
+
+class OrdenTrabajo(models.Model):
+    """Órdenes de trabajo de mantenimiento."""
+
+    PRIORIDAD_CHOICES = [
+        ('BAJA', 'Baja'),
+        ('NORMAL', 'Normal'),
+        ('ALTA', 'Alta'),
+        ('URGENTE', 'Urgente'),
+    ]
+
+    ESTADO_CHOICES = [
+        ('ABIERTA', 'Abierta'),
+        ('ASIGNADA', 'Asignada'),
+        ('EN_PROCESO', 'En Proceso'),
+        ('PAUSADA', 'Pausada'),
+        ('COMPLETADA', 'Completada'),
+        ('CANCELADA', 'Cancelada'),
+    ]
+
+    codigo = models.CharField(max_length=30, unique=True, verbose_name="Código")
+    tipo = models.ForeignKey(TipoMantenimiento, on_delete=models.PROTECT)
+    maquina = models.ForeignKey(
+        'core.Maquina',
+        on_delete=models.PROTECT,
+        related_name='ordenes_trabajo',
+    )
+    plan_mantenimiento = models.ForeignKey(
+        PlanMantenimiento,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='ordenes_generadas',
+    )
+    prioridad = models.CharField(
+        max_length=10,
+        choices=PRIORIDAD_CHOICES,
+        default='NORMAL',
+    )
+    estado = models.CharField(
+        max_length=20,
+        choices=ESTADO_CHOICES,
+        default='ABIERTA',
+    )
+    titulo = models.CharField(max_length=200)
+    descripcion = models.TextField()
+    fecha_creacion = models.DateTimeField(auto_now_add=True)
+    fecha_planificada = models.DateTimeField(null=True, blank=True)
+    fecha_inicio = models.DateTimeField(null=True, blank=True)
+    fecha_fin = models.DateTimeField(null=True, blank=True)
+    duracion_real_horas = models.DecimalField(
+        max_digits=6,
+        decimal_places=2,
+        null=True,
+        blank=True,
+        editable=False,
+    )
+    creada_por = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        related_name='ordenes_creadas',
+    )
+    asignada_a = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='ordenes_asignadas',
+    )
+    completada_por = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='ordenes_completadas',
+    )
+    trabajo_realizado = models.TextField(blank=True)
+    observaciones = models.TextField(blank=True)
+    requiere_parada_produccion = models.BooleanField(default=False)
+    costo_estimado = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        null=True,
+        blank=True,
+    )
+    costo_real = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        app_label = 'core'
+        verbose_name = "Orden de Trabajo"
+        verbose_name_plural = "Órdenes de Trabajo"
+        ordering = ['-fecha_creacion']
+
+    def __str__(self):
+        return f"{self.codigo} - {self.titulo}"
+
+    def save(self, *args, **kwargs):
+        if self.fecha_inicio and self.fecha_fin:
+            delta = self.fecha_fin - self.fecha_inicio
+            self.duracion_real_horas = round(Decimal(delta.total_seconds() / 3600), 2)
+        super().save(*args, **kwargs)
+
+
+class OrdenTrabajoRepuesto(models.Model):
+    """Repuestos utilizados en órdenes de trabajo."""
+
+    orden_trabajo = models.ForeignKey(
+        OrdenTrabajo,
+        on_delete=models.CASCADE,
+        related_name='repuestos_utilizados',
+    )
+    repuesto = models.ForeignKey('core.Repuesto', on_delete=models.PROTECT)
+    cantidad_planificada = models.IntegerField(validators=[MinValueValidator(1)])
+    cantidad_real = models.IntegerField(
+        validators=[MinValueValidator(0)],
+        default=0,
+    )
+    fecha_uso = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        app_label = 'core'
+        verbose_name = "Repuesto de Orden de Trabajo"
+        verbose_name_plural = "Repuestos de Órdenes de Trabajo"
+
+    def __str__(self):
+        return f"{self.orden_trabajo.codigo} - {self.repuesto.nombre}"
+
+
+class HistorialMantenimiento(models.Model):
+    """Historial consolidado de mantenimientos por máquina."""
+
+    maquina = models.ForeignKey(
+        'core.Maquina',
+        on_delete=models.CASCADE,
+        related_name='historial_mantenimiento',
+    )
+    orden_trabajo = models.ForeignKey(
+        OrdenTrabajo,
+        on_delete=models.CASCADE,
+        related_name='historial',
+    )
+    fecha = models.DateTimeField()
+    tipo = models.ForeignKey(TipoMantenimiento, on_delete=models.PROTECT)
+    descripcion = models.TextField()
+    tiempo_parada_horas = models.DecimalField(max_digits=6, decimal_places=2)
+    costo = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True)
+    realizado_por = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        related_name='mantenimientos_realizados',
+    )
+
+    class Meta:
+        app_label = 'core'
+        verbose_name = "Historial de Mantenimiento"
+        verbose_name_plural = "Historiales de Mantenimiento"
+        ordering = ['-fecha']
+
+    def __str__(self):
+        return f"{self.maquina.codigo} - {self.fecha.strftime('%Y-%m-%d')}"
+
+
+class IndicadorMantenimiento(models.Model):
+    """KPIs de mantenimiento (MTBF, MTTR, Disponibilidad)."""
+
+    PERIODO_CHOICES = [
+        ('SEMANAL', 'Semanal'),
+        ('MENSUAL', 'Mensual'),
+        ('ANUAL', 'Anual'),
+    ]
+
+    maquina = models.ForeignKey(
+        'core.Maquina',
+        on_delete=models.CASCADE,
+        related_name='indicadores_mantenimiento',
+    )
+    periodo = models.CharField(max_length=10, choices=PERIODO_CHOICES)
+    fecha_inicio = models.DateField()
+    fecha_fin = models.DateField()
+    mtbf_horas = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        help_text="Mean Time Between Failures",
+    )
+    mttr_horas = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        help_text="Mean Time To Repair",
+    )
+    disponibilidad_porcentaje = models.DecimalField(max_digits=5, decimal_places=2)
+    numero_fallas = models.IntegerField()
+    numero_mantenimientos_preventivos = models.IntegerField()
+    numero_mantenimientos_correctivos = models.IntegerField()
+    costo_total_mantenimiento = models.DecimalField(max_digits=12, decimal_places=2)
+    fecha_calculo = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        app_label = 'core'
+        verbose_name = "Indicador de Mantenimiento"
+        verbose_name_plural = "Indicadores de Mantenimiento"
+        ordering = ['-fecha_inicio']
+        unique_together = ['maquina', 'periodo', 'fecha_inicio']
+
+    def __str__(self):
+        return f"{self.maquina.codigo} - {self.periodo} ({self.fecha_inicio} - {self.fecha_fin})"

--- a/backend/mantenimiento/serializers.py
+++ b/backend/mantenimiento/serializers.py
@@ -1,0 +1,55 @@
+"""Serializers del dominio de mantenimiento."""
+
+from rest_framework import serializers
+
+from .models import OrdenTrabajo, TipoMantenimiento
+
+
+class TipoMantenimientoSerializer(serializers.ModelSerializer):
+    """Serializer de tipos de mantenimiento."""
+
+    class Meta:
+        model = TipoMantenimiento
+        fields = ['id', 'codigo', 'nombre', 'descripcion', 'activo']
+        read_only_fields = ['id']
+
+
+class OrdenTrabajoListSerializer(serializers.ModelSerializer):
+    """Serializer simplificado para listados de OT."""
+
+    maquina_nombre = serializers.CharField(source='maquina.nombre', read_only=True)
+    tipo_nombre = serializers.CharField(source='tipo.nombre', read_only=True)
+    estado_display = serializers.CharField(source='get_estado_display', read_only=True)
+    prioridad_display = serializers.CharField(source='get_prioridad_display', read_only=True)
+
+    class Meta:
+        model = OrdenTrabajo
+        fields = [
+            'id', 'codigo', 'maquina', 'maquina_nombre',
+            'tipo', 'tipo_nombre', 'prioridad', 'prioridad_display',
+            'estado', 'estado_display', 'titulo', 'fecha_creacion',
+            'fecha_planificada', 'asignada_a',
+        ]
+
+
+class OrdenTrabajoSerializer(serializers.ModelSerializer):
+    """Serializer completo de órdenes de trabajo."""
+
+    maquina_nombre = serializers.CharField(source='maquina.nombre', read_only=True)
+    tipo_nombre = serializers.CharField(source='tipo.nombre', read_only=True)
+    estado_display = serializers.CharField(source='get_estado_display', read_only=True)
+    prioridad_display = serializers.CharField(source='get_prioridad_display', read_only=True)
+    creada_por_nombre = serializers.CharField(source='creada_por.get_full_name', read_only=True)
+
+    class Meta:
+        model = OrdenTrabajo
+        fields = [
+            'id', 'codigo', 'tipo', 'tipo_nombre', 'maquina', 'maquina_nombre',
+            'prioridad', 'prioridad_display', 'estado', 'estado_display',
+            'titulo', 'descripcion', 'fecha_creacion', 'fecha_planificada',
+            'fecha_inicio', 'fecha_fin', 'duracion_real_horas',
+            'creada_por', 'creada_por_nombre', 'asignada_a', 'completada_por',
+            'trabajo_realizado', 'observaciones', 'requiere_parada_produccion',
+            'costo_estimado', 'costo_real',
+        ]
+        read_only_fields = ['id', 'fecha_creacion', 'duracion_real_horas', 'creada_por']

--- a/backend/mantenimiento/urls.py
+++ b/backend/mantenimiento/urls.py
@@ -1,0 +1,36 @@
+"""Rutas del dominio de mantenimiento."""
+
+from django.urls import include, path
+from rest_framework.routers import SimpleRouter
+
+from .views import OrdenTrabajoViewSet, TipoMantenimientoViewSet
+
+router = SimpleRouter()
+router.register(r'ordenes-trabajo', OrdenTrabajoViewSet, basename='ordenestrabajo')
+router.register(r'tipos-mantenimiento', TipoMantenimientoViewSet, basename='tipomantenimiento')
+
+orden_trabajo_list = OrdenTrabajoViewSet.as_view({'get': 'list', 'post': 'create'})
+orden_trabajo_detail = OrdenTrabajoViewSet.as_view(
+    {
+        'get': 'retrieve',
+        'put': 'update',
+        'patch': 'partial_update',
+        'delete': 'destroy',
+    }
+)
+
+extra_patterns = [
+    path('abiertas/', OrdenTrabajoViewSet.as_view({'get': 'abiertas'}), name='mantenimiento-abiertas'),
+    path('<int:pk>/asignar/', OrdenTrabajoViewSet.as_view({'post': 'asignar'}), name='mantenimiento-asignar'),
+    path('<int:pk>/iniciar/', OrdenTrabajoViewSet.as_view({'post': 'iniciar'}), name='mantenimiento-iniciar'),
+    path('<int:pk>/pausar/', OrdenTrabajoViewSet.as_view({'post': 'pausar'}), name='mantenimiento-pausar'),
+    path('<int:pk>/completar/', OrdenTrabajoViewSet.as_view({'post': 'completar'}), name='mantenimiento-completar'),
+    path('<int:pk>/cerrar/', OrdenTrabajoViewSet.as_view({'post': 'cerrar'}), name='mantenimiento-cerrar'),
+]
+
+urlpatterns = [
+    path('', orden_trabajo_list, name='mantenimiento-list'),
+    path('<int:pk>/', orden_trabajo_detail, name='mantenimiento-detail'),
+    *extra_patterns,
+    path('', include(router.urls)),
+]

--- a/backend/mantenimiento/views.py
+++ b/backend/mantenimiento/views.py
@@ -1,0 +1,261 @@
+"""Vistas del dominio de mantenimiento."""
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from rest_framework import filters, permissions, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from core.permissions import IsAdmin, IsAdminOrSupervisor
+
+from .models import OrdenTrabajo, TipoMantenimiento
+from .serializers import (
+    OrdenTrabajoListSerializer,
+    OrdenTrabajoSerializer,
+    TipoMantenimientoSerializer,
+)
+
+User = get_user_model()
+
+
+class TipoMantenimientoViewSet(viewsets.ModelViewSet):
+    """ViewSet para gestionar Tipos de Mantenimiento."""
+
+    queryset = TipoMantenimiento.objects.all().order_by('codigo')
+    serializer_class = TipoMantenimientoSerializer
+
+    def get_permissions(self):
+        if self.request.method in permissions.SAFE_METHODS:
+            perm_classes = [permissions.IsAuthenticated]
+        else:
+            perm_classes = [IsAdmin]
+        return [p() for p in perm_classes]
+
+
+class OrdenTrabajoViewSet(viewsets.ModelViewSet):
+    """ViewSet para gestionar Órdenes de Trabajo."""
+
+    queryset = (
+        OrdenTrabajo.objects.select_related('tipo', 'maquina', 'creada_por', 'asignada_a')
+        .all()
+        .order_by('-fecha_creacion')
+    )
+    serializer_class = OrdenTrabajoSerializer
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ['codigo', 'titulo', 'maquina__nombre']
+    ordering_fields = ['fecha_creacion', 'fecha_planificada', 'prioridad']
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+
+        # Filtro por máquina
+        maquina_id = self.request.query_params.get('maquina', None)
+        if maquina_id:
+            queryset = queryset.filter(maquina_id=maquina_id)
+
+        # Filtro por tipo
+        tipo_id = self.request.query_params.get('tipo', None)
+        if tipo_id:
+            queryset = queryset.filter(tipo_id=tipo_id)
+
+        # Filtro por estado
+        estado = self.request.query_params.get('estado', None)
+        if estado:
+            queryset = queryset.filter(estado=estado.upper())
+
+        # Filtro por prioridad
+        prioridad = self.request.query_params.get('prioridad', None)
+        if prioridad:
+            queryset = queryset.filter(prioridad=prioridad.upper())
+
+        return queryset
+
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return OrdenTrabajoListSerializer
+        return OrdenTrabajoSerializer
+
+    def get_permissions(self):
+        if self.request.method in permissions.SAFE_METHODS:
+            perm_classes = [permissions.IsAuthenticated]
+        else:
+            perm_classes = [IsAdmin]
+        return [p() for p in perm_classes]
+
+    def perform_create(self, serializer):
+        serializer.save(creada_por=self.request.user)
+
+    @action(detail=False, methods=['get'])
+    def abiertas(self, request):
+        """Endpoint: /api/mantenimiento/ordenes-trabajo/abiertas/"""
+
+        ordenes = self.get_queryset().exclude(estado__in=['COMPLETADA', 'CANCELADA'])
+        serializer = self.get_serializer(ordenes, many=True)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=['post'], permission_classes=[IsAdminOrSupervisor])
+    def asignar(self, request, pk=None):
+        """Endpoint: /api/mantenimiento/ordenes-trabajo/{id}/asignar/."""
+
+        ot = self.get_object()
+
+        if ot.estado not in ['ABIERTA', 'ASIGNADA']:
+            return Response(
+                {'error': f'No se puede asignar una OT en estado {ot.get_estado_display()}'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        tecnico_id = request.data.get('tecnico_id')
+        if not tecnico_id:
+            return Response(
+                {'error': 'Debe proporcionar el ID del técnico (tecnico_id)'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            tecnico = User.objects.get(id=tecnico_id)
+        except User.DoesNotExist:
+            return Response(
+                {'error': f'Usuario con ID {tecnico_id} no existe'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        ot.asignada_a = tecnico
+        ot.estado = 'ASIGNADA'
+        ot.save()
+
+        serializer = self.get_serializer(ot)
+        return Response(
+            {
+                'message': f'OT asignada a {tecnico.get_full_name()}',
+                'orden_trabajo': serializer.data,
+            }
+        )
+
+    @action(detail=True, methods=['post'], permission_classes=[permissions.IsAuthenticated])
+    def iniciar(self, request, pk=None):
+        """Endpoint: /api/mantenimiento/ordenes-trabajo/{id}/iniciar/."""
+
+        ot = self.get_object()
+
+        # Solo el técnico asignado o un admin puede iniciar
+        if ot.asignada_a and ot.asignada_a != request.user and not request.user.is_superuser:
+            return Response(
+                {'error': 'Solo el técnico asignado puede iniciar esta OT'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        if ot.estado not in ['ASIGNADA', 'PAUSADA']:
+            return Response(
+                {'error': f'No se puede iniciar una OT en estado {ot.get_estado_display()}'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        ot.estado = 'EN_PROCESO'
+        if not ot.fecha_inicio:
+            ot.fecha_inicio = timezone.now()
+        ot.save()
+
+        serializer = self.get_serializer(ot)
+        return Response(
+            {
+                'message': 'OT iniciada exitosamente',
+                'orden_trabajo': serializer.data,
+            }
+        )
+
+    @action(detail=True, methods=['post'], permission_classes=[permissions.IsAuthenticated])
+    def pausar(self, request, pk=None):
+        """Endpoint: /api/mantenimiento/ordenes-trabajo/{id}/pausar/."""
+
+        ot = self.get_object()
+
+        if ot.estado != 'EN_PROCESO':
+            return Response(
+                {'error': 'Solo se pueden pausar OT en proceso'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        motivo = request.data.get('motivo', '')
+        if not motivo:
+            return Response(
+                {'error': 'Debe proporcionar un motivo de pausa'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        ot.estado = 'PAUSADA'
+        ot.observaciones = f"{ot.observaciones}\n\nPAUSADA: {motivo} ({timezone.now()})".strip()
+        ot.save()
+
+        serializer = self.get_serializer(ot)
+        return Response(
+            {
+                'message': 'OT pausada exitosamente',
+                'orden_trabajo': serializer.data,
+            }
+        )
+
+    @action(detail=True, methods=['post'], permission_classes=[permissions.IsAuthenticated])
+    def completar(self, request, pk=None):
+        """Endpoint: /api/mantenimiento/ordenes-trabajo/{id}/completar/."""
+
+        ot = self.get_object()
+
+        if ot.estado not in ['EN_PROCESO', 'PAUSADA']:
+            return Response(
+                {'error': f'No se puede completar una OT en estado {ot.get_estado_display()}'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        trabajo_realizado = request.data.get('trabajo_realizado', '')
+        if not trabajo_realizado:
+            return Response(
+                {'error': 'Debe describir el trabajo realizado'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        costo_real = request.data.get('costo_real')
+
+        ot.estado = 'COMPLETADA'
+        ot.fecha_fin = timezone.now()
+        ot.trabajo_realizado = trabajo_realizado
+        ot.completada_por = request.user
+
+        if costo_real:
+            ot.costo_real = costo_real
+
+        ot.save()
+
+        serializer = self.get_serializer(ot)
+        return Response(
+            {
+                'message': 'OT completada exitosamente',
+                'orden_trabajo': serializer.data,
+            }
+        )
+
+    @action(detail=True, methods=['post'], permission_classes=[IsAdminOrSupervisor])
+    def cerrar(self, request, pk=None):
+        """Endpoint: /api/mantenimiento/ordenes-trabajo/{id}/cerrar/."""
+
+        ot = self.get_object()
+
+        if ot.estado != 'COMPLETADA':
+            return Response(
+                {'error': 'Solo se pueden cerrar OT completadas'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        comentarios = request.data.get('comentarios', '')
+        if comentarios:
+            ot.observaciones = f"{ot.observaciones}\n\nCERRADA: {comentarios} ({timezone.now()})".strip()
+
+        ot.save()
+
+        serializer = self.get_serializer(ot)
+        return Response(
+            {
+                'message': 'OT cerrada exitosamente',
+                'orden_trabajo': serializer.data,
+            }
+        )

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -73,6 +73,7 @@ INSTALLED_APPS = [
     'backend.usuarios',
     'backend.produccion',
     'backend.inventario',
+    'backend.mantenimiento',
     'core',
 ]
 

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/produccion/', include('backend.produccion.urls')),
     path('api/inventario/', include('backend.inventario.urls')),
+    path('api/mantenimiento/', include('backend.mantenimiento.urls')),
     path('api/', include("core.urls")),  # 👈 importante
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),

--- a/core/admin.py
+++ b/core/admin.py
@@ -7,9 +7,6 @@ from .models import (
     # Catálogos
     Ubicacion, Maquina, Producto, Formula,
     EtapaProduccion, Turno, TipoDocumento,
-    # Mantenimiento
-    TipoMantenimiento, PlanMantenimiento, OrdenTrabajo,
-    OrdenTrabajoRepuesto, HistorialMantenimiento, IndicadorMantenimiento,
     # Incidentes
     TipoIncidente, Incidente, InvestigacionIncidente, AccionCorrectiva,
     # Auditoría
@@ -76,53 +73,6 @@ class TipoDocumentoAdmin(admin.ModelAdmin):
     list_display = ['codigo', 'nombre', 'activo']
     list_filter = ['activo']
     search_fields = ['codigo', 'nombre']
-
-
-# ============================================
-# MANTENIMIENTO
-# ============================================
-
-@admin.register(TipoMantenimiento)
-class TipoMantenimientoAdmin(admin.ModelAdmin):
-    list_display = ['codigo', 'nombre', 'activo']
-    list_filter = ['activo']
-    search_fields = ['codigo', 'nombre']
-
-
-@admin.register(PlanMantenimiento)
-class PlanMantenimientoAdmin(admin.ModelAdmin):
-    list_display = ['codigo', 'maquina', 'nombre', 'tipo', 'activo']
-    list_filter = ['tipo', 'activo', 'maquina']
-    search_fields = ['codigo', 'nombre']
-
-
-class OrdenTrabajoRepuestoInline(admin.TabularInline):
-    model = OrdenTrabajoRepuesto
-    extra = 1
-
-
-@admin.register(OrdenTrabajo)
-class OrdenTrabajoAdmin(admin.ModelAdmin):
-    list_display = ['codigo', 'maquina', 'tipo', 'prioridad', 'estado', 'fecha_creacion', 'asignada_a']
-    list_filter = ['tipo', 'prioridad', 'estado', 'fecha_creacion']
-    search_fields = ['codigo', 'titulo']
-    date_hierarchy = 'fecha_creacion'
-    readonly_fields = ['duracion_real_horas', 'fecha_creacion']
-    inlines = [OrdenTrabajoRepuestoInline]
-
-
-@admin.register(HistorialMantenimiento)
-class HistorialMantenimientoAdmin(admin.ModelAdmin):
-    list_display = ['maquina', 'tipo', 'fecha', 'tiempo_parada_horas', 'realizado_por']
-    list_filter = ['tipo', 'fecha', 'maquina']
-    date_hierarchy = 'fecha'
-
-
-@admin.register(IndicadorMantenimiento)
-class IndicadorMantenimientoAdmin(admin.ModelAdmin):
-    list_display = ['maquina', 'periodo', 'fecha_inicio', 'mtbf_horas', 'mttr_horas', 'disponibilidad_porcentaje']
-    list_filter = ['periodo', 'maquina']
-    date_hierarchy = 'fecha_inicio'
 
 
 # ============================================

--- a/core/models.py
+++ b/core/models.py
@@ -11,6 +11,14 @@ from decimal import Decimal
 import hashlib
 
 from backend.usuarios.models import Rol, UserProfile, UsuarioRol
+from backend.mantenimiento.models import (
+    HistorialMantenimiento,
+    IndicadorMantenimiento,
+    OrdenTrabajo,
+    OrdenTrabajoRepuesto,
+    PlanMantenimiento,
+    TipoMantenimiento,
+)
 
 
 # ============================================
@@ -298,176 +306,6 @@ class DocumentoVersionado(models.Model):
 # 4. MÓDULO: INVENTARIO
 # ============================================
 
-# ============================================
-# 5. MÓDULO: MANTENIMIENTO
-# ============================================
-
-class TipoMantenimiento(models.Model):
-    """Tipos de mantenimiento"""
-    
-    codigo = models.CharField(max_length=10, unique=True, verbose_name="Código")
-    nombre = models.CharField(max_length=50)
-    descripcion = models.TextField(blank=True, verbose_name="Descripción")
-    activo = models.BooleanField(default=True)
-    
-    class Meta:
-        verbose_name = "Tipo de Mantenimiento"
-        verbose_name_plural = "Tipos de Mantenimiento"
-        ordering = ['codigo']
-    
-    def __str__(self):
-        return f"{self.codigo} - {self.nombre}"
-
-
-class PlanMantenimiento(models.Model):
-    """Planes de mantenimiento preventivo"""
-    
-    codigo = models.CharField(max_length=30, unique=True, verbose_name="Código")
-    maquina = models.ForeignKey(Maquina, on_delete=models.CASCADE, related_name='planes_mantenimiento')
-    nombre = models.CharField(max_length=200)
-    descripcion = models.TextField(blank=True, verbose_name="Descripción")
-    tipo = models.ForeignKey(TipoMantenimiento, on_delete=models.PROTECT)
-    frecuencia_dias = models.IntegerField(null=True, blank=True, help_text="Frecuencia en días")
-    frecuencia_horas_uso = models.IntegerField(null=True, blank=True, help_text="Frecuencia en horas de uso")
-    frecuencia_ciclos = models.IntegerField(null=True, blank=True, help_text="Frecuencia en ciclos de operación")
-    tareas = models.JSONField(default=list, help_text="Lista de tareas: [{nombre, descripcion, duracion_min}]")
-    repuestos_necesarios = models.JSONField(default=list, help_text="Lista de repuestos: [{repuesto_id, cantidad}]")
-    duracion_estimada_horas = models.DecimalField(max_digits=5, decimal_places=2)
-    activo = models.BooleanField(default=True)
-    creado_por = models.ForeignKey(User, on_delete=models.PROTECT, related_name='planes_creados')
-    fecha_creacion = models.DateTimeField(auto_now_add=True)
-    
-    class Meta:
-        verbose_name = "Plan de Mantenimiento"
-        verbose_name_plural = "Planes de Mantenimiento"
-        ordering = ['maquina', 'codigo']
-    
-    def __str__(self):
-        return f"{self.codigo} - {self.nombre}"
-
-
-class OrdenTrabajo(models.Model):
-    """Órdenes de trabajo de mantenimiento"""
-    
-    PRIORIDAD_CHOICES = [
-        ('BAJA', 'Baja'),
-        ('NORMAL', 'Normal'),
-        ('ALTA', 'Alta'),
-        ('URGENTE', 'Urgente'),
-    ]
-    
-    ESTADO_CHOICES = [
-        ('ABIERTA', 'Abierta'),
-        ('ASIGNADA', 'Asignada'),
-        ('EN_PROCESO', 'En Proceso'),
-        ('PAUSADA', 'Pausada'),
-        ('COMPLETADA', 'Completada'),
-        ('CANCELADA', 'Cancelada'),
-    ]
-    
-    codigo = models.CharField(max_length=30, unique=True, verbose_name="Código")
-    tipo = models.ForeignKey(TipoMantenimiento, on_delete=models.PROTECT)
-    maquina = models.ForeignKey(Maquina, on_delete=models.PROTECT, related_name='ordenes_trabajo')
-    plan_mantenimiento = models.ForeignKey(PlanMantenimiento, on_delete=models.SET_NULL, null=True, blank=True, related_name='ordenes_generadas')
-    prioridad = models.CharField(max_length=10, choices=PRIORIDAD_CHOICES, default='NORMAL')
-    estado = models.CharField(max_length=20, choices=ESTADO_CHOICES, default='ABIERTA')
-    titulo = models.CharField(max_length=200)
-    descripcion = models.TextField()
-    fecha_creacion = models.DateTimeField(auto_now_add=True)
-    fecha_planificada = models.DateTimeField(null=True, blank=True)
-    fecha_inicio = models.DateTimeField(null=True, blank=True)
-    fecha_fin = models.DateTimeField(null=True, blank=True)
-    duracion_real_horas = models.DecimalField(max_digits=6, decimal_places=2, null=True, blank=True, editable=False)
-    creada_por = models.ForeignKey(User, on_delete=models.PROTECT, related_name='ordenes_creadas')
-    asignada_a = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True, related_name='ordenes_asignadas')
-    completada_por = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True, related_name='ordenes_completadas')
-    trabajo_realizado = models.TextField(blank=True)
-    observaciones = models.TextField(blank=True)
-    requiere_parada_produccion = models.BooleanField(default=False)
-    costo_estimado = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True)
-    costo_real = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True)
-    
-    class Meta:
-        verbose_name = "Orden de Trabajo"
-        verbose_name_plural = "Órdenes de Trabajo"
-        ordering = ['-fecha_creacion']
-    
-    def __str__(self):
-        return f"{self.codigo} - {self.titulo}"
-    
-    def save(self, *args, **kwargs):
-        if self.fecha_inicio and self.fecha_fin:
-            delta = self.fecha_fin - self.fecha_inicio
-            self.duracion_real_horas = round(Decimal(delta.total_seconds() / 3600), 2)
-        super().save(*args, **kwargs)
-
-
-class OrdenTrabajoRepuesto(models.Model):
-    """Repuestos utilizados en órdenes de trabajo"""
-    
-    orden_trabajo = models.ForeignKey(OrdenTrabajo, on_delete=models.CASCADE, related_name='repuestos_utilizados')
-    repuesto = models.ForeignKey('core.Repuesto', on_delete=models.PROTECT)
-    cantidad_planificada = models.IntegerField(validators=[MinValueValidator(1)])
-    cantidad_real = models.IntegerField(validators=[MinValueValidator(0)], default=0)
-    fecha_uso = models.DateTimeField(null=True, blank=True)
-    
-    class Meta:
-        verbose_name = "Repuesto de Orden de Trabajo"
-        verbose_name_plural = "Repuestos de Órdenes de Trabajo"
-    
-    def __str__(self):
-        return f"{self.orden_trabajo.codigo} - {self.repuesto.nombre}"
-
-
-class HistorialMantenimiento(models.Model):
-    """Historial consolidado de mantenimientos por máquina"""
-    
-    maquina = models.ForeignKey(Maquina, on_delete=models.CASCADE, related_name='historial_mantenimiento')
-    orden_trabajo = models.ForeignKey(OrdenTrabajo, on_delete=models.CASCADE, related_name='historial')
-    fecha = models.DateTimeField()
-    tipo = models.ForeignKey(TipoMantenimiento, on_delete=models.PROTECT)
-    descripcion = models.TextField()
-    tiempo_parada_horas = models.DecimalField(max_digits=6, decimal_places=2)
-    costo = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True)
-    realizado_por = models.ForeignKey(User, on_delete=models.PROTECT, related_name='mantenimientos_realizados')
-    
-    class Meta:
-        verbose_name = "Historial de Mantenimiento"
-        verbose_name_plural = "Historiales de Mantenimiento"
-        ordering = ['-fecha']
-    
-    def __str__(self):
-        return f"{self.maquina.codigo} - {self.fecha.strftime('%Y-%m-%d')}"
-
-
-class IndicadorMantenimiento(models.Model):
-    """KPIs de mantenimiento (MTBF, MTTR, Disponibilidad)"""
-    
-    PERIODO_CHOICES = [
-        ('SEMANAL', 'Semanal'),
-        ('MENSUAL', 'Mensual'),
-        ('ANUAL', 'Anual'),
-    ]
-    
-    maquina = models.ForeignKey(Maquina, on_delete=models.CASCADE, related_name='indicadores_mantenimiento')
-    periodo = models.CharField(max_length=10, choices=PERIODO_CHOICES)
-    fecha_inicio = models.DateField()
-    fecha_fin = models.DateField()
-    mtbf_horas = models.DecimalField(max_digits=10, decimal_places=2, help_text="Mean Time Between Failures")
-    mttr_horas = models.DecimalField(max_digits=10, decimal_places=2, help_text="Mean Time To Repair")
-    disponibilidad_porcentaje = models.DecimalField(max_digits=5, decimal_places=2)
-    numero_fallas = models.IntegerField()
-    numero_mantenimientos_preventivos = models.IntegerField()
-    numero_mantenimientos_correctivos = models.IntegerField()
-    costo_total_mantenimiento = models.DecimalField(max_digits=12, decimal_places=2)
-    fecha_calculo = models.DateTimeField(auto_now_add=True)
-    
-    class Meta:
-        verbose_name = "Indicador de Mantenimiento"
-        verbose_name_plural = "Indicadores de Mantenimiento"
-        ordering = ['-fecha_inicio']
-        unique_together = ['maquina', 'periodo', 'fecha_inicio']
-    
     def __str__(self):
         return f"{self.maquina.codigo} - {self.get_periodo_display()} ({self.fecha_inicio})"
 

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -9,8 +9,6 @@ from .models import (
     Ubicacion, Maquina, Producto, Formula, EtapaProduccion, Turno,
     # Calidad
     Desviacion, DocumentoVersionado,
-    # Mantenimiento
-    TipoMantenimiento, OrdenTrabajo,
     # Incidentes
     TipoIncidente, Incidente, AccionCorrectiva,
     # Auditoría
@@ -94,58 +92,6 @@ class TurnoSerializer(serializers.ModelSerializer):
         model = Turno
         fields = ['id', 'codigo', 'nombre', 'nombre_display', 'hora_inicio', 'hora_fin', 'activo']
         read_only_fields = ['id']
-
-
-# ============================================
-# MANTENIMIENTO
-# ============================================
-
-class TipoMantenimientoSerializer(serializers.ModelSerializer):
-    """Serializer de tipos de mantenimiento"""
-    
-    class Meta:
-        model = TipoMantenimiento
-        fields = ['id', 'codigo', 'nombre', 'descripcion', 'activo']
-        read_only_fields = ['id']
-
-
-class OrdenTrabajoListSerializer(serializers.ModelSerializer):
-    """Serializer simplificado para listados de OT"""
-    maquina_nombre = serializers.CharField(source='maquina.nombre', read_only=True)
-    tipo_nombre = serializers.CharField(source='tipo.nombre', read_only=True)
-    estado_display = serializers.CharField(source='get_estado_display', read_only=True)
-    prioridad_display = serializers.CharField(source='get_prioridad_display', read_only=True)
-    
-    class Meta:
-        model = OrdenTrabajo
-        fields = [
-            'id', 'codigo', 'maquina', 'maquina_nombre',
-            'tipo', 'tipo_nombre', 'prioridad', 'prioridad_display',
-            'estado', 'estado_display', 'titulo', 'fecha_creacion',
-            'fecha_planificada', 'asignada_a'
-        ]
-
-
-class OrdenTrabajoSerializer(serializers.ModelSerializer):
-    """Serializer completo de órdenes de trabajo"""
-    maquina_nombre = serializers.CharField(source='maquina.nombre', read_only=True)
-    tipo_nombre = serializers.CharField(source='tipo.nombre', read_only=True)
-    estado_display = serializers.CharField(source='get_estado_display', read_only=True)
-    prioridad_display = serializers.CharField(source='get_prioridad_display', read_only=True)
-    creada_por_nombre = serializers.CharField(source='creada_por.get_full_name', read_only=True)
-    
-    class Meta:
-        model = OrdenTrabajo
-        fields = [
-            'id', 'codigo', 'tipo', 'tipo_nombre', 'maquina', 'maquina_nombre',
-            'prioridad', 'prioridad_display', 'estado', 'estado_display',
-            'titulo', 'descripcion', 'fecha_creacion', 'fecha_planificada',
-            'fecha_inicio', 'fecha_fin', 'duracion_real_horas',
-            'creada_por', 'creada_por_nombre', 'asignada_a', 'completada_por',
-            'trabajo_realizado', 'observaciones', 'requiere_parada_produccion',
-            'costo_estimado', 'costo_real'
-        ]
-        read_only_fields = ['id', 'fecha_creacion', 'duracion_real_horas', 'creada_por']
 
 
 # ============================================

--- a/core/signals.py
+++ b/core/signals.py
@@ -7,7 +7,8 @@ from django.db.models.signals import post_save, pre_save, post_delete
 from django.dispatch import receiver
 from django.contrib.auth.models import User
 from threading import local
-from .models import LogAuditoria, Notificacion, Incidente, OrdenTrabajo
+from .models import LogAuditoria, Notificacion, Incidente
+from backend.mantenimiento.models import OrdenTrabajo
 from backend.produccion.models import Lote, LoteEtapa
 from backend.usuarios.models import UserProfile
 import json

--- a/core/urls.py
+++ b/core/urls.py
@@ -10,8 +10,6 @@ from .views import (
     EtapaProduccionViewSet, TurnoViewSet,
     # Calidad
     DesviacionViewSet, AccionCorrectivaViewSet, DocumentoVersionadoViewSet,
-    # Mantenimiento
-    TipoMantenimientoViewSet, OrdenTrabajoViewSet,
     # Incidentes
     TipoIncidenteViewSet, IncidenteViewSet,
     # Notificaciones
@@ -43,10 +41,6 @@ router.register(r'turnos', TurnoViewSet)
 router.register(r'desviaciones', DesviacionViewSet)
 router.register(r'acciones-correctivas', AccionCorrectivaViewSet)
 router.register(r'documentos', DocumentoVersionadoViewSet)
-
-# Mantenimiento
-router.register(r'tipos-mantenimiento', TipoMantenimientoViewSet)
-router.register(r'ordenes-trabajo', OrdenTrabajoViewSet)
 
 # Incidentes
 router.register(r'tipos-incidente', TipoIncidenteViewSet)

--- a/core/views.py
+++ b/core/views.py
@@ -11,7 +11,6 @@ from django.http import JsonResponse
 from django.conf import settings
 from django.db import connections
 from django.db.utils import OperationalError
-from django.contrib.auth.models import User
 from datetime import datetime, timedelta
 
 from .models import (
@@ -20,7 +19,7 @@ from .models import (
     # Calidad
     Desviacion, DocumentoVersionado,
     # Mantenimiento
-    TipoMantenimiento, OrdenTrabajo,
+    OrdenTrabajo,
     # Incidentes
     TipoIncidente, Incidente, AccionCorrectiva,
     # Auditoría
@@ -33,8 +32,6 @@ from .serializers import (
     FormulaSerializer, EtapaProduccionSerializer, TurnoSerializer,
     # Calidad
     DesviacionSerializer, DocumentoVersionadoSerializer,
-    # Mantenimiento
-    TipoMantenimientoSerializer, OrdenTrabajoSerializer, OrdenTrabajoListSerializer,
     # Incidentes
     TipoIncidenteSerializer, IncidenteSerializer, IncidenteListSerializer, AccionCorrectivaSerializer,
     # Notificaciones y Auditoría
@@ -218,233 +215,6 @@ class TurnoViewSet(viewsets.ModelViewSet):
 # ============================================
 
 
-
-
-# ============================================
-# MANTENIMIENTO
-# ============================================
-
-class TipoMantenimientoViewSet(viewsets.ModelViewSet):
-    """ViewSet para gestionar Tipos de Mantenimiento"""
-    queryset = TipoMantenimiento.objects.all().order_by('codigo')
-    serializer_class = TipoMantenimientoSerializer
-    
-    def get_permissions(self):
-        if self.request.method in permissions.SAFE_METHODS:
-            perm_classes = [permissions.IsAuthenticated]
-        else:
-            perm_classes = [IsAdmin]
-        return [p() for p in perm_classes]
-
-
-class OrdenTrabajoViewSet(viewsets.ModelViewSet):
-    """ViewSet para gestionar �rdenes de Trabajo"""
-    queryset = OrdenTrabajo.objects.select_related(
-        'tipo', 'maquina', 'creada_por', 'asignada_a'
-    ).all().order_by('-fecha_creacion')
-    serializer_class = OrdenTrabajoSerializer
-    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
-    search_fields = ['codigo', 'titulo', 'maquina__nombre']
-    ordering_fields = ['fecha_creacion', 'fecha_planificada', 'prioridad']
-    
-    def get_queryset(self):
-        queryset = super().get_queryset()
-        
-        # Filtro por m�quina
-        maquina_id = self.request.query_params.get('maquina', None)
-        if maquina_id:
-            queryset = queryset.filter(maquina_id=maquina_id)
-        
-        # Filtro por tipo
-        tipo_id = self.request.query_params.get('tipo', None)
-        if tipo_id:
-            queryset = queryset.filter(tipo_id=tipo_id)
-        
-        # Filtro por estado
-        estado = self.request.query_params.get('estado', None)
-        if estado:
-            queryset = queryset.filter(estado=estado.upper())
-        
-        # Filtro por prioridad
-        prioridad = self.request.query_params.get('prioridad', None)
-        if prioridad:
-            queryset = queryset.filter(prioridad=prioridad.upper())
-        
-        return queryset
-    
-    def get_serializer_class(self):
-        if self.action == 'list':
-            return OrdenTrabajoListSerializer
-        return OrdenTrabajoSerializer
-    
-    def get_permissions(self):
-        if self.request.method in permissions.SAFE_METHODS:
-            perm_classes = [permissions.IsAuthenticated]
-        else:
-            perm_classes = [IsAdmin]
-        return [p() for p in perm_classes]
-    
-    def perform_create(self, serializer):
-        serializer.save(creada_por=self.request.user)
-    
-    @action(detail=False, methods=['get'])
-    def abiertas(self, request):
-        """Endpoint: /api/ordenes-trabajo/abiertas/"""
-        ordenes = self.get_queryset().exclude(estado__in=['COMPLETADA', 'CANCELADA'])
-        serializer = self.get_serializer(ordenes, many=True)
-        return Response(serializer.data)
-    
-    @action(detail=True, methods=['post'], permission_classes=[IsAdminOrSupervisor])
-    def asignar(self, request, pk=None):
-        """Endpoint: /api/ordenes-trabajo/{id}/asignar/"""
-        ot = self.get_object()
-        
-        if ot.estado not in ['ABIERTA', 'ASIGNADA']:
-            return Response(
-                {'error': f'No se puede asignar una OT en estado {ot.get_estado_display()}'},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        
-        tecnico_id = request.data.get('tecnico_id')
-        if not tecnico_id:
-            return Response(
-                {'error': 'Debe proporcionar el ID del técnico (tecnico_id)'},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        
-        try:
-            tecnico = User.objects.get(id=tecnico_id)
-        except User.DoesNotExist:
-            return Response(
-                {'error': f'Usuario con ID {tecnico_id} no existe'},
-                status=status.HTTP_404_NOT_FOUND
-            )
-        
-        ot.asignada_a = tecnico
-        ot.estado = 'ASIGNADA'
-        ot.save()
-        
-        serializer = self.get_serializer(ot)
-        return Response({
-            'message': f'OT asignada a {tecnico.get_full_name()}',
-            'orden_trabajo': serializer.data
-        })
-    
-    @action(detail=True, methods=['post'], permission_classes=[permissions.IsAuthenticated])
-    def iniciar(self, request, pk=None):
-        """Endpoint: /api/ordenes-trabajo/{id}/iniciar/"""
-        ot = self.get_object()
-        
-        # Solo el técnico asignado o un admin puede iniciar
-        if ot.asignada_a and ot.asignada_a != request.user and not request.user.is_superuser:
-            return Response(
-                {'error': 'Solo el técnico asignado puede iniciar esta OT'},
-                status=status.HTTP_403_FORBIDDEN
-            )
-        
-        if ot.estado not in ['ASIGNADA', 'PAUSADA']:
-            return Response(
-                {'error': f'No se puede iniciar una OT en estado {ot.get_estado_display()}'},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        
-        ot.estado = 'EN_PROCESO'
-        if not ot.fecha_inicio:
-            ot.fecha_inicio = timezone.now()
-        ot.save()
-        
-        serializer = self.get_serializer(ot)
-        return Response({
-            'message': 'OT iniciada exitosamente',
-            'orden_trabajo': serializer.data
-        })
-    
-    @action(detail=True, methods=['post'], permission_classes=[permissions.IsAuthenticated])
-    def pausar(self, request, pk=None):
-        """Endpoint: /api/ordenes-trabajo/{id}/pausar/"""
-        ot = self.get_object()
-        
-        if ot.estado != 'EN_PROCESO':
-            return Response(
-                {'error': 'Solo se pueden pausar OT en proceso'},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        
-        motivo = request.data.get('motivo', '')
-        if not motivo:
-            return Response(
-                {'error': 'Debe proporcionar un motivo de pausa'},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        
-        ot.estado = 'PAUSADA'
-        ot.observaciones = f"{ot.observaciones}\n\nPAUSADA: {motivo} ({timezone.now()})".strip()
-        ot.save()
-        
-        serializer = self.get_serializer(ot)
-        return Response({
-            'message': 'OT pausada exitosamente',
-            'orden_trabajo': serializer.data
-        })
-    
-    @action(detail=True, methods=['post'], permission_classes=[permissions.IsAuthenticated])
-    def completar(self, request, pk=None):
-        """Endpoint: /api/ordenes-trabajo/{id}/completar/"""
-        ot = self.get_object()
-        
-        if ot.estado not in ['EN_PROCESO', 'PAUSADA']:
-            return Response(
-                {'error': f'No se puede completar una OT en estado {ot.get_estado_display()}'},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        
-        trabajo_realizado = request.data.get('trabajo_realizado', '')
-        if not trabajo_realizado:
-            return Response(
-                {'error': 'Debe describir el trabajo realizado'},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        
-        costo_real = request.data.get('costo_real')
-        
-        ot.estado = 'COMPLETADA'
-        ot.fecha_fin = timezone.now()
-        ot.trabajo_realizado = trabajo_realizado
-        ot.completada_por = request.user
-        
-        if costo_real:
-            ot.costo_real = costo_real
-        
-        ot.save()
-        
-        serializer = self.get_serializer(ot)
-        return Response({
-            'message': 'OT completada exitosamente',
-            'orden_trabajo': serializer.data
-        })
-    
-    @action(detail=True, methods=['post'], permission_classes=[IsAdminOrSupervisor])
-    def cerrar(self, request, pk=None):
-        """Endpoint: /api/ordenes-trabajo/{id}/cerrar/ - Cierre administrativo"""
-        ot = self.get_object()
-        
-        if ot.estado != 'COMPLETADA':
-            return Response(
-                {'error': 'Solo se pueden cerrar OT completadas'},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        
-        comentarios = request.data.get('comentarios', '')
-        if comentarios:
-            ot.observaciones = f"{ot.observaciones}\n\nCERRADA: {comentarios} ({timezone.now()})".strip()
-        
-        ot.save()
-        
-        serializer = self.get_serializer(ot)
-        return Response({
-            'message': 'OT cerrada exitosamente',
-            'orden_trabajo': serializer.data
-        })
 
 
 # ============================================


### PR DESCRIPTION
## Summary
- extracted the maintenance domain into the new `backend.mantenimiento` app while keeping the original `core` app label on every model
- moved serializers, viewsets, admin registrations and routing so `/api/mantenimiento/` serves the maintenance CRUD without creating new migrations
- wired the app into project settings/URLs and updated `core` to import from the new module instead of defining maintenance code inline

## Testing
- SECRET_KEY=dummy python manage.py makemigrations
- SECRET_KEY=dummy python manage.py migrate
- SECRET_KEY=dummy python manage.py shell -c "from django.urls import reverse; print(reverse('mantenimiento-list'))"


------
https://chatgpt.com/codex/tasks/task_e_68e6827fe5308328bdca222f553e9b83